### PR TITLE
Update rotate method in case input angle is zero

### DIFF
--- a/vtkplotter/actors.py
+++ b/vtkplotter/actors.py
@@ -386,6 +386,8 @@ class Prop(object):
             anglerad = angle
         else:
             anglerad = np.deg2rad(angle)
+        if not anglerad:
+            return self
         axis = utils.versor(axis)
         a = np.cos(anglerad / 2)
         b, c, d = -axis * np.sin(anglerad / 2)


### PR DESCRIPTION
This is useful when getting angle and rotation axis from unit quaternion in vtk: output axis is zero that leads for time being to an error in vtkplotter rotate method (vtkplotter tries to normalize the zero vector)

With patch, we save some computation and prevent from crashing when axis is zero 

Below is the code that show the output we have from vtk with a unit quaternion

    import vtk
    q = vtk.vtkQuaterniond([1.0,0.0,0.0,0.0])
    res = [666.0]*3
    angle = q.GetRotationAngleAndAxis(res)
    print(res)
    # [0.0, 0.0, 0.0]
    print(angle)
    # 0.0