### PR TITLE
Added onClose event on qt-examples to fix issue 51

### DIFF
--- a/examples/other/qt_tabs.py
+++ b/examples/other/qt_tabs.py
@@ -19,6 +19,10 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         
         self.plt.show()
 
+    def onClose(self):
+        print("Disable the interactor before closing to prevent it from trying to act on a already deleted items")
+        self.vtkWidget.close()
+
 
 if __name__ == "__main__":
     import sys
@@ -26,5 +30,6 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
 
     window = MainWindow()
+    app.aboutToQuit.connect(window.onClose)  # <-- connect the onClose event
     window.show()
     sys.exit(app.exec_())

--- a/examples/other/qt_window.py
+++ b/examples/other/qt_window.py
@@ -29,8 +29,13 @@ class MainWindow(Qt.QMainWindow):
 
         self.show()    # <--- show the Qt Window
 
+    def onClose(self):
+        print("Disable the interactor before closing to prevent it from trying to act on a already deleted items")
+        self.vtkWidget.close()
+
 
 if __name__ == "__main__":
     app = Qt.QApplication(sys.argv)
     window = MainWindow()
+    app.aboutToQuit.connect(window.onClose) # <-- connect the onClose event
     app.exec_()

--- a/examples/other/qt_window_split.py
+++ b/examples/other/qt_window_split.py
@@ -53,8 +53,13 @@ class MainWindow(Qt.QMainWindow):
         r.ResetCamera()
         self.iren.Start()
 
+    def onClose(self):
+        print("Disable the interactor before closing to prevent it from trying to act on a already deleted items")
+        self.vtkWidget.close()
+
 
 if __name__ == "__main__":
     app = Qt.QApplication(sys.argv)
     window = MainWindow()
+    app.aboutToQuit.connect(window.onClose)
     app.exec_()


### PR DESCRIPTION
@marcomusy 

I've added on-close events to the three qt-examples (qt-window, qt-window-split, qt-window-tabs).
Before applying this fix I had an error-window on closing the qt-tabs example. This is seems to have disappeared after this fix.
Note: checking if this really fixed it is difficult as the error does not always materialize. Probably because it depends on the speed and order of destruction of the objects and interactor.